### PR TITLE
Add sliding underline hover effect to top 6 navbar links

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -33,6 +33,23 @@ body {
     margin: 10px;
     transition: color 0.3s;
     display: flex;
+    display: inline-block; 
+    position: relative;
+}
+
+.navbar a:nth-child(-n+6)::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    height: 1.5px;
+    width: 0%;
+    background-color: rgba(0, 0, 0, 0.889);
+    transition: width 0.4s ease;
+}
+
+.navbar a:nth-child(-n+6):hover::after {
+    width: 100%;
 }
 
 .navbar a.btn {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -380,6 +380,14 @@ body {
     border-radius: 50%;
     background-color: white;
     border: 1px solid white;
+    transition: transform 0.3s ease, color 0.3s ease;
+}
+
+.footer .social svg:hover {
+    transform: scale(1.05);
+    background-color: rgba(245, 244, 244, 0.466);
+    border: 1px solid rgba(245, 244, 244, 0.466);
+    transition: transform 0.3s ease, color 0.3s ease;
 }
 
 .footer .contact {


### PR DESCRIPTION
### Title of the Pull Request
**feat: Add sliding underline hover effect to top 6 navbar links**

---

### Description
This PR enhances the navbar UI by adding a sliding underline hover effect to the **first 6 links**. The animation creates a sleek, modern visual cue for users, improving the interactivity of the navigation bar.

---

### Changes Made
- Added `::after` pseudo-element to `.navbar a` for underline.
- Used `:nth-child(-n+6)` to restrict effect to only the first 6 links.
- Transition added for smooth slide-in effect.

---

### Code Snippet
```css
.navbar a {
    color: black;
    text-decoration: none;
    margin: 10px;
    transition: color 0.3s;
    display: inline-block;
    position: relative;
}

.navbar a:nth-child(-n+6)::after {
    content: '';
    position: absolute;
    left: 0;
    bottom: 0;
    height: 2px;
    width: 0%;
    background-color: black;
    transition: width 0.3s ease;
}

.navbar a:nth-child(-n+6):hover::after {
    width: 100%;
}
```
---

### 📸Screenshots 

<img width="1390" height="96" alt="image" src="https://github.com/user-attachments/assets/389452e3-fb5b-44c2-8754-b88aad4defbf" />

<img width="1234" height="142" alt="image" src="https://github.com/user-attachments/assets/0c240a71-b79a-49ed-8f30-feeef61f3b85" />

---

### Checklist
 - UI changes tested on different screen sizes.
 - Animation tested for smoothness and performance.
 - Only applied to top 6 links as intended.
 
---

Linked Issue (if any)
Closes #10 