### PR TITLE
Fix: dark mode resets on page load

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -6,3 +6,23 @@ function toggleDarkMode()
     element.classList.toggle("dark")
 
 }
+
+function toggleDarkMode() {
+    const element = document.getElementById("main-body");
+
+    element.classList.toggle("dark");
+
+    if(element.classList.contains("dark")){
+        localStorage.setItem("theme","dark");
+    } else{
+        localStorage.setItem("theme","light");
+    }
+}
+
+
+ if (localStorage.getItem("theme") === "dark") {
+      document.addEventListener("DOMContentLoaded", function () {
+        document.getElementById("main-body")?.classList.add("dark");
+      });
+ }
+


### PR DESCRIPTION
This PR fixes an issue where dark mode resets on page refereshing or reload.
I've made changes using localStorage to store the user's theme preference.

Let me know if any changes are needed!
Fixes #47 