### PR TITLE
feature:  Add “Why Learn With Us” Section Above Testimonials – closes #73

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,34 @@
             </section>
 
     </div>
+     <!-- Why Learn With Us Section -->
+  <section id="why-learn">
+    <h2>Why Learn With Creators' Space?</h2>
+    <div class="why-grid">
+      <div class="why-card">
+        <div class="why-icon">🎓</div>
+        <h3>Industry-Ready Courses</h3>
+        <p>Designed by experts to match real-world skills.</p>
+      </div>
+      <div class="why-card">
+        <div class="why-icon">📜</div>
+        <h3>Certificates of Completion</h3>
+        <p>Verifiable and shareable achievements.</p>
+      </div>
+      <div class="why-card">
+        <div class="why-icon">💼</div>
+        <h3>Career Opportunities</h3>
+        <p>Internship and job assistance for top learners.</p>
+      </div>
+      <div class="why-card">
+        <div class="why-icon">🧠</div>
+        <h3>Project-Based Learning</h3>
+        <p>Learn by building real-world projects.</p>
+      </div>
+      
+    </div>
+  </section>
+
 
       <!-- testimonial Start -->
   <div class="margin-top-5">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -664,3 +664,66 @@ body.dark .testimonial-card {
   background-color: #fff;
   color: #222;
 }
+/* Why Learn With Us Section */
+#why-learn {
+  padding: 60px 20px;
+  background: #f0f4f8;
+}
+
+#why-learn h2 {
+  text-align: center;
+  margin-bottom: 40px;
+  font-size: 2em;
+}
+
+.why-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.why-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 20px;
+  transition: all 0.3s ease;
+  border: 2px solid transparent;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  text-align: center;
+}
+
+.why-card:hover {
+  border: 2px solid #4a90e2;
+  background: #ffffff;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  transform: translateY(-5px);
+  cursor: pointer;
+}
+
+.why-icon {
+  font-size: 32px;
+  margin-bottom: 10px;
+}
+
+.why-card h3 {
+  font-size: 1.2em;
+  margin: 10px 0;
+}
+
+.why-card p {
+  font-size: 0.95em;
+  color: #555;
+}
+
+@media (max-width: 600px) {
+  #why-learn {
+    padding: 40px 10px;
+  }
+
+  .why-card {
+    padding: 16px;
+  }
+}
+


### PR DESCRIPTION
This pull request implements a new UI section on the homepage titled **“Why Learn With Creators’ Space?”**, as proposed in Issue #73.

🧩 The section highlights platform benefits such as:
- Industry-ready courses
- Certificates
- Career opportunities
- Project-based learning

🎨 It follows the current website theme, is fully responsive, and is placed right above the testimonials section.

This enhancement aims to increase user engagement and encourage signups by showcasing what makes Creators' Space valuable.

✅ Closes: #73
<img width="1703" height="431" alt="Screenshot 2025-07-31 193803" src="https://github.com/user-attachments/assets/6e1ab41a-eb0b-446f-91c9-f599e1a2dbc7" />
<img width="1660" height="410" alt="Screenshot 2025-07-31 193822" src="https://github.com/user-attachments/assets/f8dfe606-462a-42a0-8595-34b17be891a7" />


🙋‍♂️ I’m contributing under GSSoC’25. Please review and merge.
