### PR TITLE
Fix: Added Bookmark Navbar to Internship page (#180)

### DIFF
--- a/internship.html
+++ b/internship.html
@@ -26,6 +26,7 @@
       <a href="internship.html">Internship</a>
       <a href="#">Campus Ambassador</a>
       <a href="blog.html">Blog</a>
+       <a href="bookmarked.html">BookMarks</a>
       <a href="./login.html" class="btn login">Log In</a>
       <a href="./signup.html" class="btn signup">Sign Up</a>
     </div>
@@ -218,7 +219,7 @@
       container.innerHTML = "<p style='color:red;text-align:center;font-size:20px;'>Couldn't load the internships.</p>";
       console.error("Error loading internships:", err);
          }
-  });
+  };
 </script>
 
   <!-- Dark Mode JS -->


### PR DESCRIPTION
Title:
Fix: Added Bookmark Navbar to Internship page (#180)

Description:
Hi! This PR fixes Issue #180 reported in the repository as part of GSSoC ’25.

Problem
The Bookmark Navbar visible on pages like Courses and Blog was missing from the Internship page, causing inconsistency in navigation.

Description of Changes:

Added the missing Bookmark Navbar to internship.html so it is consistent with other pages (e.g., Courses, Blog).

Ensured the structure and styles match the existing implementation used across the site.

Before:

The Bookmark Navbar was not visible on the Internship page, making navigation inconsistent.

After:

The Bookmark Navbar now appears on the Internship page, allowing quick jumps between sections.

Note:

The screenshot may show a missing logo in my local setup because my clone was from an earlier state of the repo. This is unrelated to the fix and does not affect functionality.

Screenshots:
Before fix:
<img width="1909" height="916" alt="Screenshot 2025-08-06 114219" src="https://github.com/user-attachments/assets/b8305c4d-5d34-47d0-b35e-a90a685b17f9" />


After fix:
<img width="1897" height="914" alt="image" src="https://github.com/user-attachments/assets/fe61caa0-f7ee-465d-865a-4d88c014af2f" />


 Related Issue
Fixes #180
