### PR TITLE
Removed the extra projects option in resources

### DIFF
--- a/campus-ambassador.html
+++ b/campus-ambassador.html
@@ -66,7 +66,6 @@
                 <a href="blog.html">Blog</a>
                 <a href="bookmarked.html">BookMarks</a>
                 <a href="./certificate/">Certificates</a>
-                <a href="projects.html">Projects</a>
                 <a href="roadmap.html">Roadmap</a>
                 </div>
             </li> 


### PR DESCRIPTION
## What is this PR about?
Removed the extra projects option shown in resources of the campus ambassador page. It helps in maintaining uniformity.
Fixes #338 