### PR TITLE
feat: add concise course descriptions to cards

### DIFF
--- a/courses.html
+++ b/courses.html
@@ -192,6 +192,9 @@
     <h3>Full Stack Web Development</h3>
     <p class="price">₹12,999 <del>₹49,999</del></p>
     <p>6 Months • Complete Bootcamp</p>
+    <p class="desc">
+      Master modern web technologies and build real-world projects to become a complete full-stack developer.
+    </p>
   </div>
 
   <!-- More Info Button -->
@@ -210,11 +213,14 @@
           <h3 data-translate="courses.webDev.title">Full Stack Web Development</h3>
           <p class="price">₹12,999 <del>₹49,999</del></p>
           <p><span data-translate="courses.webDev.duration">6 Months</span> • Complete Bootcamp</p>
+          <p class="desc">
+      Master modern web technologies and build real-world projects to become a complete full-stack developer.
+    </p>
         </div>
         <!-- Hover Button -->
         <div class="expandable-box">
           <button class="info-btn" id="toggle-info">More Info</button>
-          <div class="info-content">
+          <div class="syllabus hidden">
             🚀 Learn HTML, CSS, JavaScript, React, Node.js, MongoDB & more.
             Perfect for beginners & professionals to become full-stack
             developers!
@@ -245,6 +251,9 @@
           <h3>C Programming Mastery</h3>
           <p class="price">₹2,999 <del>₹12,999</del></p>
           <p>3 Months • Foundation Course</p>
+          <p class="desc">
+      Master C programming from scratch, learn data types, pointers, memory management, file handling, and algorithms for a strong software foundation.
+    </p>
         </div>
         <div class="expandable-box">
           <button class="info-btn" id="toggle-info">More Info</button>
@@ -281,6 +290,9 @@
     <h3>C Programming Mastery</h3>
     <p class="price">₹2,999 <del>₹12,999</del></p>
     <p>3 Months • Foundation Course</p>
+    <p class="desc">
+      Master C programming from scratch, learn data types, pointers, memory management, file handling, and algorithms for a strong software foundation.
+    </p>
   </div>
 
   <!-- More Info Button -->
@@ -308,6 +320,9 @@
     <h3>Python Programming Pro</h3>
     <p class="price">₹2,999 <del>₹12,999</del></p>
     <p>3 Months • Beginner to Advanced</p>
+    <p class="desc">
+      Learn Python fundamentals, OOP, data analysis, and automation through hands-on coding challenges and projects.
+    </p>
   </div>
 
   <!-- More Info Button -->
@@ -336,6 +351,9 @@
     <h3>UI/UX Design Essentials</h3>
     <p class="price">₹5,999 <del>₹19,999</del></p>
     <p>4 Months • Design Thinking & Prototyping</p>
+    <p class="desc">
+      Explore design thinking, wireframing, prototyping, and usability testing to create user-friendly digital experiences.
+    </p>
   </div>
 
   <!-- More Info Button -->
@@ -369,6 +387,9 @@
     <h3>Graphic Designing Masterclass</h3>
     <p class="price">₹4,499 <del>₹12,999</del></p>
     <p>3 Months • Creative Suite Training</p>
+    <p class="desc">
+      Gain expertise in Photoshop, Illustrator, and digital design principles to craft stunning visuals and branding.
+    </p>
   </div>
 
   <!-- More Info Button -->
@@ -399,6 +420,9 @@
     <h3>Data Analytics & Visualization</h3>
     <p class="price">₹7,999 <del>₹19,999</del></p>
     <p>4 Months • Excel, Power BI & Tableau</p>
+    <p class="desc">
+      Learn Excel, SQL, Power BI, and Python to analyze data, generate insights, and make data-driven decisions.
+    </p>
   </div>
 
   <!-- More Info Button -->
@@ -430,6 +454,9 @@
           <h3>Python Programming Pro</h3>
           <p class="price">₹2,999 <del>₹12,999</del></p>
           <p>3 Months • Beginner to Advanced</p>
+          <p class="desc">
+      Learn Python fundamentals, OOP, data analysis, and automation through hands-on coding challenges and projects.
+    </p>
         </div>
         <div class="expandable-box">
           <button class="info-btn" id="toggle-info">More Info</button>
@@ -467,6 +494,9 @@
           <h3>UI/UX Design Essentials</h3>
           <p class="price">₹5,999 <del>₹19,999</del></p>
           <p>4 Months • Design Thinking & Prototyping</p>
+          <p class="desc">
+      Explore design thinking, wireframing, prototyping, and usability testing to create user-friendly digital experiences.
+    </p>
         </div>
         <div class="expandable-box">
           <button class="info-btn" id="toggle-info">More Info</button>
@@ -504,6 +534,9 @@
           <h3>Graphic Designing Masterclass</h3>
           <p class="price">₹4,499 <del>₹12,999</del></p>
           <p>3 Months • Creative Suite Training</p>
+          <p class="desc">
+      Gain expertise in Photoshop, Illustrator, and digital design principles to craft stunning visuals and branding.
+    </p>
         </div>
         <div class="expandable-box">
           <button class="info-btn" id="toggle-info">More Info</button>
@@ -539,6 +572,9 @@
           <h3>Data Analytics & Visualization</h3>
           <p class="price">₹7,999 <del>₹19,999</del></p>
           <p>4 Months • Excel, Power BI & Tableau</p>
+          <p class="desc">
+      Learn Excel, SQL, Power BI, and Python to analyze data, generate insights, and make data-driven decisions.
+    </p>
         </div>
         <div class="expandable-box">
           <button class="info-btn" id="toggle-info">More Info</button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Creators-Space",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/style.css
+++ b/style.css
@@ -31,6 +31,13 @@
   right: 0;
   box-shadow: 0 4px 12px rgba(0,0,0,0.3);
 }
+.desc {
+  font-size: 0.9rem;
+  color: #444;
+  margin: 8px 0;
+  line-height: 1.4;
+  min-height: 42px; /* keeps card heights aligned */
+}
 
 .chat-body {
   flex: 1;


### PR DESCRIPTION
## Description
Course cards now display short 2–3 line descriptions below the duration.  
This helps users quickly understand what each course covers without expanding the syllabus.

## Changes Made
- Updated `courses.html` to add `<p class="desc">` under each course card.
- Added `.desc` styling in `style.css` for consistent font, spacing, and responsiveness.

## Screenshots
Before:
 
<img width="1366" height="768" alt="Screenshot (62)" src="https://github.com/user-attachments/assets/5c453165-1b00-4652-af30-eac5776a6449" />

After:

<img width="1366" height="768" alt="Screenshot (63)" src="https://github.com/user-attachments/assets/f78af44b-d83d-40e5-823f-c50927cf1184" />

Fixes: #270 