### PR TITLE
add missing translation widget

### DIFF
--- a/about.html
+++ b/about.html
@@ -667,7 +667,8 @@
     <script src="./src/js/auth.js"></script>
     <script src="./src/js/utils.js"></script>
     <script src="./src/js/slider.js"></script>
-
+    <script src="./src/js/language.js"></script>
+    
     <script src="./src/js/newsletter.js"></script>
     <script src="./src/js/about.js"></script>
     <script src="./src/js/scrollToTop.js"></script>

--- a/campus-ambassador.html
+++ b/campus-ambassador.html
@@ -345,6 +345,7 @@
     </footer>
     <script src="./src/js/auth.js"></script> 
     <script src="./src/js/utils.js"></script>
+    <script src="./src/js/language.js"></script>
 </body>
 
 </html>

--- a/contact.html
+++ b/contact.html
@@ -397,10 +397,11 @@
       </div>
     </footer>
 
-    <!-- Scripts -->
-    <script src="./src/js/navbar.js"></script>
-    <script src="./src/js/utils.js"></script>
-    <script src="./src/js/contact.js"></script>
-    <script src="./src/js/auth.js" defer type="module"></script>
-  </body>
+  <!-- Scripts -->
+  <script src="./src/js/navbar.js"></script>
+  <script src="./src/js/utils.js"></script>
+  <script src="./src/js/contact.js"></script>
+  <script src="./src/js/auth.js" defer type="module"></script>
+  <script src="./src/js/language.js"></script>
+</body>
 </html>

--- a/courses.html
+++ b/courses.html
@@ -939,6 +939,7 @@ document.addEventListener("DOMContentLoaded", function () {
 </script>
     <script src="./src/js/auth.js"></script>
     <script src="script.js" defer></script>
+    
     <!-- Bootstrap JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 


### PR DESCRIPTION
Closes #397 
Description:
Missing translation widget in navbar from some pages has been added.

Contact page navbar before:
<img width="1919" height="352" alt="image" src="https://github.com/user-attachments/assets/f9996ff9-a46f-4ba1-b2fb-557becc1e783" />

Contact page navbar after:
<img width="1918" height="352" alt="image" src="https://github.com/user-attachments/assets/cd9d005a-8abc-4525-9151-90181fe37ed5" />
