### PR TITLE
Added dark mode styles in Campus Ambassador Page

### DIFF
--- a/campus-ambassador.html
+++ b/campus-ambassador.html
@@ -10,7 +10,6 @@
     <link rel="stylesheet" href="./src/css/responsive.css">
     <link rel="stylesheet" href="./src/css/campus-ambassador.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css" integrity="sha512-DxV+EoADOkOygM4IR9yXP8Sb2qwgidEmeqAEmDKIOfPRQZOWbXCzLC6vjbZyy0vPisbH2SyW27+ddLVCN+OMzQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-</head>
 
     <script>
         function toggleDarkMode() {

--- a/src/css/campus-ambassador.css
+++ b/src/css/campus-ambassador.css
@@ -641,4 +641,22 @@ body.dark .benefit-card:hover {
   font-size: 0.95rem;
   line-height: 1.5;
 }
- 
+/* Dark mode for the extra info section */
+body.dark .extra-info {
+    background: linear-gradient(
+        135deg,
+        rgba(60, 60, 80, 0.8),
+        rgba(80, 80, 100, 0.9)
+    ) !important;
+    color: #f5f5f5 !important;
+}
+
+/* Ensure all text in dark mode stays readable */
+body.dark .why-subtitle,
+body.dark .section-title,
+body.dark .benefits-title {
+    color: #f5f5f5 !important;
+    background: linear-gradient(90deg, #a78bfa, #6a5acd);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1259,3 +1259,132 @@ body.dark-mode .hero-section h1,
 body.dark-mode .main h1 {
   color: #f5f5f5 !important; /* Ensure headings are white */
 }
+/* ==================== */
+/* Dark Mode Base Styles */
+/* ==================== */
+body.dark {
+    background-color: #121212 !important;
+    color: #f5f5f5 !important;
+}
+
+/* Navbar Dark Mode */
+body.dark .navbar {
+    background-color: #1e1e1e !important;
+    border-bottom: 1px solid #333;
+}
+
+body.dark .navbar a,
+body.dark .navbar h1 {
+    color: #f5f5f5 !important;
+}
+
+
+/* Campus Ambassador Section Dark Mode */
+body.dark .campus-ambassador-section {
+    background-color: #1a1a1a !important;
+}
+
+body.dark .benefit-card,
+body.dark .cta-section {
+    background: #2c2c2c !important;
+    border-color: #444 !important;
+    color: #f5f5f5 !important;
+}
+
+body.dark .benefit-card h3,
+body.dark .cta-section h3 {
+    color: #ffffff !important;
+}
+
+body.dark .benefit-card p,
+body.dark .cta-section p {
+    color: #cccccc !important;
+}
+
+/* About Campus Section Dark Mode */
+body.dark .about-campus {
+    background: #1a1a1a !important;
+}
+
+body.dark .why-content,
+body.dark .container {
+    background: #2c2c2c !important;
+    color: #f5f5f5 !important;
+}
+
+body.dark .left {
+    background: #333 !important;
+    color: #f5f5f5 !important;
+}
+
+body.dark .right h3 {
+    color: #f5f5f5 !important;
+}
+
+/* Responsibilities Section Dark Mode */
+body.dark .responsibilities {
+    background: #1a1a1a !important;
+}
+
+body.dark .card {
+    background: #2c2c2c !important;
+    color: #f5f5f5 !important;
+}
+
+body.dark .card h3 {
+    color: #ffffff !important;
+}
+
+body.dark .card p {
+    color: #cccccc !important;
+}
+
+body.dark .section-subtitle {
+    color: #cccccc !important;
+}
+
+/* Footer Dark Mode */
+body.dark .footer {
+    background-color: #1e1e1e !important;
+    color: #f5f5f5 !important;
+}
+
+body.dark .footer a {
+    color: #f5f5f5 !important;
+}
+
+/* Buttons Dark Mode */
+body.dark .btn.login {
+    border: 1px solid #f5f5f5 !important;
+    color: #f5f5f5 !important;
+}
+
+body.dark .btn.login:hover {
+    background-color: #f5f5f5 !important;
+    color: #121212 !important;
+}
+
+body.dark .btn.signup {
+    background-color: #f5f5f5 !important;
+    color: #121212 !important;
+    border: 1px solid #f5f5f5 !important;
+}
+
+body.dark .btn.signup:hover {
+    background-color: #121212 !important;
+    color: #f5f5f5 !important;
+}
+
+/* Dropdown Dark Mode */
+body.dark .dropdown {
+    background-color: #2c2c2c !important;
+    border: 1px solid #444 !important;
+}
+
+body.dark .dropdown a {
+    color: #f5f5f5 !important;
+}
+
+body.dark .dropdown a:hover {
+    background-color: #3c3c3c !important;
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #410 

## Rationale for this change

The Campus Ambassador page had inconsistent dark mode styling — while the header and footer switched correctly, some middle sections remained in light mode. This created a broken user experience.

## What changes are included in this PR?

- Updated dark mode styles for all middle sections of the Campus Ambassador page.
- Ensured uniform dark mode application across header, content, and footer.

## Are these changes tested?

Yes, tested manually by toggling between light and dark mode and confirming that all sections now switch consistently.

## Are there any user-facing changes?

Yes, users will now see a seamless dark mode experience across the entire Campus Ambassador page.

https://github.com/user-attachments/assets/333d3a39-efd1-4502-8b3c-65428c0bafd3

