### PR TITLE
Added light/dark mode toggle in Freelancing Page

### DIFF
--- a/freelancing.html
+++ b/freelancing.html
@@ -31,6 +31,22 @@
       --radius-2xl: 26px;
     }
 
+    /* Light Mode Variables */
+    :root[data-theme="light"] {
+      --bg: #f8fafc;
+      --bg-elev: #ffffff;
+      --card: #ffffff;
+      --muted: #64748b;
+      --text: #1e293b;
+      --accent: #0d9488;
+      --accent-2: #7c3aed;
+      --ring: #e2e8f0;
+      --ok: #059669;
+      --warn: #d97706;
+      --danger: #dc2626;
+      --shadow: 0 10px 25px rgba(0,0,0,.08), 0 6px 12px rgba(0,0,0,.05);
+    }
+
     * { box-sizing: border-box; }
     html, body { height: 100%; }
     body {
@@ -41,9 +57,53 @@
                   var(--bg);
       color: var(--text);
       line-height: 1.55;
+      transition: background-color 0.3s ease, color 0.3s ease;
     }
 
-    
+    /* Light mode background adjustments */
+    :root[data-theme="light"] body {
+      background: radial-gradient(1200px 800px at 10% -20%, rgba(13,148,136,.08), transparent 40%),
+                  radial-gradient(1000px 600px at 110% -10%, rgba(124,58,237,.06), transparent 45%),
+                  var(--bg);
+    }
+
+    /* Theme Toggle Button */
+    .theme-toggle {
+      background: var(--bg-elev);
+      border: 1px solid var(--ring);
+      border-radius: 12px;
+      padding: 8px 12px;
+      cursor: pointer;
+      color: var(--text);
+      font-size: 14px;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      transition: all 0.3s ease;
+      box-shadow: var(--shadow);
+    }
+
+    .theme-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+    }
+
+    .theme-toggle i {
+      font-size: 16px;
+    }
+
+    /* Navbar adjustments for theme toggle */
+    .navbar {
+      position: relative;
+    }
+
+    .nav-links {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+
     .hero {
       position: relative;
       padding: clamp(28px, 5vw, 64px) 18px 24px;
@@ -64,6 +124,11 @@
       animation: spin 28s linear infinite;
       pointer-events: none;
     }
+
+    :root[data-theme="light"] .glow {
+      opacity: .12;
+    }
+
     @keyframes spin { to { transform: rotate(360deg); } }
 
     .title {
@@ -82,6 +147,11 @@
       background: linear-gradient(180deg, rgba(11,15,20,.85), rgba(11,15,20,.60));
       border-bottom: 1px solid var(--ring);
     }
+
+    :root[data-theme="light"] .toolbar {
+      background: linear-gradient(180deg, rgba(248,250,252,.85), rgba(248,250,252,.60));
+    }
+
     .toolbar-inner{
       max-width: 1150px; margin: 0 auto; padding: 12px 16px; display: grid; gap: 12px; align-items: center;
       grid-template-columns: 1fr auto; 
@@ -94,8 +164,15 @@
       transition: transform .15s ease, background .2s ease, border-color .2s ease;
       user-select: none;
     }
+
+    :root[data-theme="light"] .chip {
+      background: rgba(0,0,0,.02);
+    }
+
     .chip:hover { transform: translateY(-1px) scale(1.02); border-color: rgba(93,214,201,.45); }
+    :root[data-theme="light"] .chip:hover { border-color: rgba(13,148,136,.45); }
     .chip.active { background: linear-gradient(180deg, rgba(93,214,201,.20), rgba(154,123,255,.18)); border-color: rgba(93,214,201,.55); }
+    :root[data-theme="light"] .chip.active { background: linear-gradient(180deg, rgba(13,148,136,.15), rgba(124,58,237,.12)); border-color: rgba(13,148,136,.55); }
 
     .search {
       display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: var(--bg-elev); border: 1px solid var(--ring);
@@ -116,6 +193,11 @@
       transform: translateY(10px) scale(.98); opacity: 0; 
       transition: transform .3s ease, box-shadow .3s ease, border-color .3s ease, opacity .6s ease;
     }
+
+    :root[data-theme="light"] .card {
+      background: linear-gradient(180deg, rgba(0,0,0,.01), rgba(0,0,0,.005)), var(--card);
+    }
+
     .card.revealed { transform: translateY(0) scale(1); opacity: 1; }
 
     .card:hover {
@@ -124,14 +206,22 @@
       border-color: rgba(93,214,201,.65);
     }
 
+    :root[data-theme="light"] .card:hover {
+      box-shadow: 0 16px 32px rgba(0,0,0,.15), 0 8px 16px rgba(0,0,0,.1);
+      border-color: rgba(13,148,136,.65);
+    }
+
     .card-header { padding: 18px 18px 8px; display:flex; gap: 12px; align-items:center; }
     .logo { width: 36px; height: 36px; border-radius: 10px; display:grid; place-items:center; font-weight:800; background: linear-gradient(135deg, rgba(93,214,201,.15), rgba(154,123,255,.15)); border: 1px solid var(--ring); }
+    :root[data-theme="light"] .logo { background: linear-gradient(135deg, rgba(13,148,136,.15), rgba(124,58,237,.15)); }
     .name { font-size: 18px; font-weight: 700; letter-spacing: -.01em; }
     .tag { font-size: 12px; padding: 4px 8px; border-radius: 999px; border: 1px solid var(--ring); color: var(--muted); }
     .card-body { padding: 0 18px 18px; color: #c9d8ec; }
+    :root[data-theme="light"] .card-body { color: #475569; }
 
     .meta { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 10px; }
     .meta .pill { background: rgba(255,255,255,.03); border: 1px solid var(--ring); border-radius: 10px; padding: 8px 10px; font-size: 12px; color: var(--muted); }
+    :root[data-theme="light"] .meta .pill { background: rgba(0,0,0,.03); }
     .meta strong { display:block; color: var(--text); font-size: 13px; margin-bottom: 2px; }
 
     .card-footer { display:flex; align-items:center; justify-content: flex-start; gap: 12px; padding: 14px 18px 18px; }
@@ -140,7 +230,11 @@
       background: linear-gradient(180deg, rgba(93,214,201,.16), rgba(154,123,255,.12)); color: var(--text); font-weight: 700; cursor: pointer; text-decoration:none;
       transition: transform .15s ease, filter .2s ease, border-color .2s ease; box-shadow: var(--shadow);
     }
+    :root[data-theme="light"] .btn {
+      background: linear-gradient(180deg, rgba(13,148,136,.12), rgba(124,58,237,.08));
+    }
     .btn:hover { transform: translateY(-1px); border-color: rgba(93,214,201,.55); }
+    :root[data-theme="light"] .btn:hover { border-color: rgba(13,148,136,.55); }
 
     .ext { font-size: 12px; color: var(--muted); }
 
@@ -189,6 +283,13 @@
        </li> 
       <a href="projects.html" data-translate="navbar.projects">Projects</a>
       <a href="contact.html" data-translate="navbar.contact">Contact</a>
+      
+      <!-- Theme Toggle Button -->
+      <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
+        <i class="fas fa-moon"></i>
+        <span>Dark</span>
+      </button>
+
       <!-- Navbar -->
       <div id="authSection">
         <a href="./login.html" class="btn login" data-translate="navbar.login">Log In</a>
@@ -249,6 +350,43 @@
   </footer>
   <script src="./src/js/navbar.js"></script>
   <script>
+    // Theme toggle functionality
+    const themeToggle = document.getElementById('themeToggle');
+    const themeIcon = themeToggle.querySelector('i');
+    const themeText = themeToggle.querySelector('span');
+    
+    // Check for saved theme preference or respect OS preference
+    const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+    const currentTheme = localStorage.getItem('theme');
+    
+    if (currentTheme === 'light' || (!currentTheme && prefersDarkScheme.matches)) {
+      setLightMode();
+    } else {
+      setDarkMode();
+    }
+    
+    themeToggle.addEventListener('click', function() {
+      if (document.documentElement.getAttribute('data-theme') === 'light') {
+        setDarkMode();
+      } else {
+        setLightMode();
+      }
+    });
+
+    function setLightMode() {
+      document.documentElement.setAttribute('data-theme', 'light');
+      themeIcon.className = 'fas fa-sun';
+      themeText.textContent = 'Light';
+      localStorage.setItem('theme', 'light');
+    }
+
+    function setDarkMode() {
+      document.documentElement.removeAttribute('data-theme');
+      themeIcon.className = 'fas fa-moon';
+      themeText.textContent = 'Dark';
+      localStorage.setItem('theme', 'dark');
+    }
+
     const platforms = [
       // BEGINNER
       {
@@ -275,7 +413,7 @@
         name: 'PeoplePerHour',
         url: 'https://www.peopleperhour.com/',
         category: 'beginner',
-        summary: 'UK-based marketplace with “offers” (fixed-price services) and project bidding.',
+        summary: 'UK-based marketplace with "offers" (fixed-price services) and project bidding.',
         fees: 'Service fee tiered',
         vetting: 'Basic application',
         payment: 'Escrow with invoices',
@@ -307,7 +445,7 @@
         name: 'Guru',
         url: 'https://www.guru.com/',
         category: 'intermediate',
-        summary: 'Flexible agreements and “WorkRooms” for collaboration.',
+        summary: 'Flexible agreements and "WorkRooms" for collaboration.',
         fees: 'Tiered fees by membership',
         vetting: 'Open signup',
         payment: 'SafePay escrow',


### PR DESCRIPTION
## Description

Added a dark/light mode toggle button to the freelancing.html page header. Previously, this page did not allow users to switch between light and dark themes, causing inconsistency across the website. With this update, users can now toggle themes on freelancing.html just like on other pages.

## Type of change

 Bug fix / UI enhancement
 
 ## Related Issue
 Closes #446 